### PR TITLE
fix import ast.ASTNode to import AST.ASTNode

### DIFF
--- a/languages/Natlab/src/natlab/utils/NodeFinder.java
+++ b/languages/Natlab/src/natlab/utils/NodeFinder.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import ast.ASTNode;
+import AST.ASTNode;
 
 import com.google.common.collect.TreeTraverser;
 


### PR DESCRIPTION
This is the cause of https://github.com/Sable/matjuice/issues/12. Since mclab-core/lib/JastAddParser/JastAddParser.jar contains 'AST' package, but not 'ast' the import should be changed respectively