### PR TITLE
Fixing error in ShapeBuiltTool

### DIFF
--- a/languages/Natlab/src/natlab/tame/builtin/Builtin.java
+++ b/languages/Natlab/src/natlab/tame/builtin/Builtin.java
@@ -5522,6 +5522,15 @@ public abstract class Builtin {
         public <Arg,Ret> Ret visit(BuiltinVisitor<Arg,Ret> visitor, Arg arg){
             return visitor.caseAbstractScalarLogicalResultVersatileQuery(this,arg);
         }
+        private SPNode shapePropInfo = null;
+        public SPNode getShapePropagationInfo(){
+            //set shapePropInfo if not defined
+            if (shapePropInfo == null){
+                // M,$ -> $
+                shapePropInfo = ShapePropTool.parse("M|$ -> $");
+            }
+            return shapePropInfo;
+        }
         
     }
     public static abstract class AbstractClassQuery extends AbstractScalarLogicalResultVersatileQuery  {
@@ -5705,7 +5714,6 @@ public abstract class Builtin {
         public <Arg,Ret> Ret visit(BuiltinVisitor<Arg,Ret> visitor, Arg arg){
             return visitor.caseAbstractScalarLogicalShapeQuery(this,arg);
         }
-        
     }
     public static class Isempty extends AbstractScalarLogicalShapeQuery  {
         //returns the singleton instance of this class

--- a/languages/Natlab/src/natlab/tame/builtin/shapeprop/ShapePropTool.java
+++ b/languages/Natlab/src/natlab/tame/builtin/shapeprop/ShapePropTool.java
@@ -120,10 +120,7 @@ public class ShapePropTool<V extends Value<V>> {
         System.out.println("print:   "+parse(
                 "M,n=previousShapeDim(1),K=copy(M),K(1)=0,(#,k=previousShapeDim(1),N=copy(#),N(1)=0,isequal(K,N),n=increment(k))*,K(1)=n->K" +
                 "||$,n=previousShapeDim(1),K=copy($),K(1)=0,(#,k=previousShapeDim(1),N=copy(#),N(1)=0,isequal(K,N),n=increment(k))*,K(1)=n->K"));
-        String s9 = parse("" +
-                "M,n=previousShapeDim(1),K=copy(M),K(1)=0,(#,k=previousShapeDim(1),N=copy(#),N(1)=0,isequal(K,N),n=increment(k))*,K(1)=n->K" +
-		System.out.println("reparsed "+parse(s9));
-		
+
 		System.out.println("print:   "+parse(
 				"M,n=previousShapeDim(2),K=copy(M),K(2)=0,(#,k=previousShapeDim(2),N=copy(#),N(2)=0,isequal(K,N),n=increment(k))*,K(2)=n->K" +
 				"||$,n=previousShapeDim(2),K=copy($),K(2)=0,(#,k=previousShapeDim(2),N=copy(#),N(2)=0,isequal(K,N),n=increment(k))*,K(2)=n->K"));


### PR DESCRIPTION
**Description**
Added fix for `ShapePropTool.java`, included shape propagation equation for Builtin set of class under: `AbstractScalarLogicalResultVersatileQuery`. For more info check the built-in tree: [Builtin Hierarchy](http://www.sable.mcgill.ca/mclab/projects/tamer/tree.png) .

Here is the equation:
```
M|$ -> $
```


**Testing Done**
Tested built on programs for this feature, created test program under my own compiler: [logical_builtins.m](https://github.com/Sable/matwably/blob/master/src/test/features/builtin/logical_builtins.m)